### PR TITLE
Fix issue with undefined Spotify platform

### DIFF
--- a/src/types/spotify.ts
+++ b/src/types/spotify.ts
@@ -2,7 +2,7 @@
 export interface SpotifyHistoryEntry {
   ts: string; // タイムスタンプ（UTC、トラックの再生が停止した時間）
   username?: string; // Spotifyのユーザー名
-  platform: string; // 再生に使用されたプラットフォーム（AndroidやGoogle Chromecastなど）
+  platform?: string; // 再生に使用されたプラットフォーム（AndroidやGoogle Chromecastなど）
   ms_played: number; // 再生時間（ミリ秒）
   conn_country: string; // 再生された国のコード（例：SE - スウェーデン）
   ip_addr_decrypted?: string; // 再生時に記録されたIPアドレス

--- a/src/utils/dataAnalysis.ts
+++ b/src/utils/dataAnalysis.ts
@@ -139,21 +139,26 @@ export function aggregateData(
   // プラットフォーム別の集計（プラットフォーム名を簡略化）
   const platformMap = new Map<string, { count: number; totalMs: number }>();
   for (const playedTrack of trackHistory) {
-    let platform = playedTrack.platform || 'Unknown';
+    // platformプロパティがundefinedの場合もあるため、必ずstring型に変換する
+    let platform = 'Unknown';
     
-    // プラットフォーム名を簡略化
-    if (platform.startsWith('iOS')) {
-      platform = platform.split(' ')[0]; // "iOS" のみを取得
-    } else if (platform.startsWith('OS X')) {
-      platform = 'macOS';
-    } else if (platform.includes('Android')) {
-      platform = 'Android';
-    } else if (platform.includes('Windows')) {
-      platform = 'Windows';
-    } else if (platform.includes('web_player')) {
-      platform = 'Web Player';
-    } else if (platform.includes('Partner')) {
-      platform = 'Partner Device';
+    if (playedTrack.platform) {
+      platform = playedTrack.platform;
+      
+      // プラットフォーム名を簡略化
+      if (platform.startsWith('iOS')) {
+        platform = platform.split(' ')[0]; // "iOS" のみを取得
+      } else if (platform.startsWith('OS X')) {
+        platform = 'macOS';
+      } else if (platform.includes('Android')) {
+        platform = 'Android';
+      } else if (platform.includes('Windows')) {
+        platform = 'Windows';
+      } else if (platform.includes('web_player')) {
+        platform = 'Web Player';
+      } else if (platform.includes('Partner')) {
+        platform = 'Partner Device';
+      }
     }
     
     const platformStats = platformMap.get(platform) || { count: 0, totalMs: 0 };


### PR DESCRIPTION
## Overview
This PR fixes the `Cannot read properties of undefined (reading 'split')` error that occurs when uploading Spotify data.

## Issue Details
Some Spotify data exports may not include the `platform` property or it might be undefined, causing the following error during data processing:

`Cannot read properties of undefined (reading 'split'))`

he error occurred in the `dataAnalysis.ts` file when trying to call the `split` method on an undefined `platform` property.

## Changes

1. **Modified data analysis logic** (`src/utils/dataAnalysis.ts`)
   - Added handling for cases where the `platform` property is `undefined`
   - Set a default value of "Unknown" and only apply simplification logic when the `platform` property exists

2. **Updated type definition** (`src/types/spotify.ts`)
   - Made the `platform` property optional in the `SpotifyHistoryEntry` interface
   - Changed to `platform?: string;` to explicitly indicate in TypeScript type checking that the `platform` may not exist

## Testing Steps
1. Upload Spotify data that doesn't contain the `platform` property
2. Verify that the data is processed correctly and the dashboard is displayed
3. Confirm that the platform usage section correctly categorizes missing platforms as "Unknown"

## Related Issue
Fixes #1 